### PR TITLE
Generalize and refine SSH config proposed in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Host *
     IdentitiesOnly yes
 ```
 
-and then specify what keys should be used for each host
+and then specify what keys should be used for each host:
 
 ```
 Host example.com

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ Host *
     IdentitiesOnly yes
 ```
 
-and then specify what keys should be used for each host:
+and above this block (the first matching option is applied,
+`Host \*` directives must come last),
+specify what keys should be used for each host:
 
 ```
 Host example.com

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ and then specify what keys should be used for each host
 Host example.com
     PubkeyAuthentication yes
     IdentityFile ~/.ssh/id_rsa
-    # IdentitiesOnly yes # Enable ssh-agent (PKCS11 etc.) keys
 ```
 
 Or, if you want to use different keys so that they can't be linked together:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Host *
     IdentitiesOnly yes
 ```
 
-And then specify what keys should be used for each host
+and then specify what keys should be used for each host
 
 ```
 Host example.com
@@ -40,11 +40,12 @@ Host example.com
     # IdentitiesOnly yes # Enable ssh-agent (PKCS11 etc.) keys
 ```
 
-If you want you can use different keys so that they can't be linked together
+Or, if you want to use different keys so that they can't be linked together:
 
 ```
 Host *
-    PubkeyAuthentication yes
+    # Only use identity files, not any identity loaded in ssh-agent
+    IdentitiesOnly yes
     # Define pattern for the names of identity files by host
     IdentityFile %d/.ssh/%h.rsa
     IdentityFile %d/.ssh/%h.dsa

--- a/README.md
+++ b/README.md
@@ -43,7 +43,13 @@ Host example.com
 If you want you can use different keys so that they can't be linked together
 
 ```
-Host github.com
+Host *
     PubkeyAuthentication yes
-    IdentityFile ~/.ssh/github_id_rsa
+    # Define pattern for the names of identity files by host
+    IdentityFile %d/.ssh/%h.rsa
+    IdentityFile %d/.ssh/%h.dsa
+    IdentityFile %d/.ssh/%h.ecdsa
+    # %d = local user's home directory
+    # %h = remote host name
+    # See IdentityFile section in `man ssh_config` for alternatives.
 ```


### PR DESCRIPTION
I propose to use the host name parameter `%h` to define a single, general configuration for separate keys for each host.

Also, I clarified usage of `PubkeyAuthentication` and `IdentitiesOnly`: it is not necessary to disable `PubkeyAuthentication` completely when `IdentitiesOnly` is set to `no` and a general configuration is in place to define explicit `IdentityFile` options for any server.
