### PR TITLE
Add /etc/ssh_config to the list of possible config locations

### DIFF
--- a/src/ssherver/server.go
+++ b/src/ssherver/server.go
@@ -104,8 +104,9 @@ var roamingMsg = []byte(strings.Replace(`
 
    THIS MEANS THAT ANY SERVER YOU CONNECT TO MIGHT OBTAIN YOUR PRIVATE KEYS.
 
-     Add "UseRoaming no" to the "Host *" section of your ~/.ssh/config or
-           /etc/ssh/ssh_config file, rotate keys and update ASAP.
+     Add "UseRoaming no" to the "Host *" section of your ~/.ssh/config,
+               /etc/ssh_config, or /etc/ssh/ssh_config file,
+                        rotate keys and update ASAP.
 
 Read more:  https://www.qualys.com/2016/01/14/cve-2016-0777-cve-2016-0778/openssh-cve-2016-0777-cve-2016-0778.txt
 `, "\n", "\n\r", -1))


### PR DESCRIPTION
I noticed that, on OSX (at least on 10.10.5), the ssh config is not stored in either of the suggested locations (`~/.ssh/config` or `/etc/ssh/ssh_config`) but rather `/etc/ssh_config`. I simply added the third option to the output string.
