### PR TITLE
Remove "all" from server message

### DIFF
--- a/server.go
+++ b/server.go
@@ -25,8 +25,8 @@ var termTmpl = template.Must(template.New("termTmpl").Parse(strings.Replace(`
     |             _o/ Hello {{ .Name }}!
     |                                                                     |
     |                                                                     |
-    |  Did you know that ssh sends all your public keys to any server     |
-    |  it tries to authenticate to?                                       |
+    |  Did you know that ssh sends your public keys to any server it      |
+    |  tries to authenticate to?                                          |
     |                                                                     |
     |  That's how we know you are @{{ .User }} on GitHub!
     |                                                                     |
@@ -52,8 +52,8 @@ var failedMsg = []byte(strings.Replace(`
     |             _o/ Hello!                                              |
     |                                                                     |
     |                                                                     |
-    |  Did you know that ssh sends all your public keys to any server     |
-    |  it tries to authenticate to? You can see yours echoed below.       |
+    |  Did you know that ssh sends your public keys to any server it      |
+    |  tries to authenticate to? You can see yours echoed below.          |
     |                                                                     |
     |  We tried to use that to find your GitHub username, but we          |
     |  couldn't :( maybe you don't even have GitHub ssh keys, do you?     |


### PR DESCRIPTION
Claiming that ssh sends *all* keys is a bit sensationalist - it just sends
the default keys. In fact, the README already states that using per-host
keys is a good mitigation.
Removing "all" from the message makes it more accurate.